### PR TITLE
FIX- Save aspect-ratio to DB

### DIFF
--- a/actions.ts
+++ b/actions.ts
@@ -221,3 +221,32 @@ export async function deleteProjectAction(projectId: string) {
   });
   return project;
 }
+
+export async function updateProjectAction(
+  projectId: string,
+  projectData: EditorProjectType
+) {
+  const session = await getServerSession(authOptions);
+  const project = await db.project.findFirst({
+    where: {
+      id: projectId,
+      user: {
+        id: session?.user.id,
+      },
+    },
+  });
+  if (!project) {
+    throw new Error("Project not found");
+  }
+  const updatedProject = await db.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      name: projectData.name,
+      aspectRatio: projectData.aspectRatio,
+      audioLink: projectData.audioLink,
+    },
+  });
+  return updatedProject;
+}

--- a/app/(flickz)/projects/[projectId]/editor/AspectRatioMenu.tsx
+++ b/app/(flickz)/projects/[projectId]/editor/AspectRatioMenu.tsx
@@ -10,19 +10,35 @@ import { getDimensionsForAspectRatio } from "@/lib/aspect-ratio";
 import { useState } from "react";
 
 interface AspectRatioMenuProps {
+  aspectRatio?: string;
+  saveProjectMetaChanges: (value: {
+    aspectRatio?: string;
+    audioLink?: string;
+  }) => void;
   setCompositionDimensions: (value: { width: number; height: number }) => void;
 }
 
+const MapAspectRatioToIcons: {
+  [key: string]: JSX.Element;
+} = {
+  "16:9": <Icons.monitor className="h-5 w-5" />,
+  "4:3": <Icons.square className="h-5 w-5" />,
+  "1:1": <Icons.smartphone className="h-5 w-5" />,
+  "4:5": <Icons.smartphone className="h-5 w-5" />,
+  "9:16": <Icons.smartphone className="h-5 w-5" />,
+};
+
 export default function AspectRatioMenu({
+  aspectRatio,
+  saveProjectMetaChanges,
   setCompositionDimensions,
 }: AspectRatioMenuProps) {
-  const [aspectRatio, setAspectRatio] = useState("16:9");
-
   const handleAspectRatioChange = (newAspectRatio: string) => {
-    setAspectRatio(newAspectRatio);
     const newDimensions = getDimensionsForAspectRatio(newAspectRatio);
     setCompositionDimensions(newDimensions);
+    saveProjectMetaChanges({ aspectRatio: newAspectRatio });
   };
+
   return (
     <div className="flex flex-col w-full space-y-6">
       <div className="flex justify-between items-center">
@@ -32,42 +48,22 @@ export default function AspectRatioMenu({
         <SelectTrigger className="w-full">
           <SelectValue>
             <div className="flex gap-4 items-center">
-              <Icons.monitor className="h-5 w-5" />
+              {(aspectRatio && MapAspectRatioToIcons[aspectRatio]) || (
+                <Icons.monitor className="h-5 w-5" />
+              )}
               <span>{aspectRatio}</span>
             </div>
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="16:9">
-            <div className="flex gap-4 justify-start">
-              <Icons.monitor className="h-5 w-5" />
-              <span>16:9</span>
-            </div>
-          </SelectItem>
-          <SelectItem value="4:3">
-            <div className="flex gap-4">
-              <Icons.square className="h-5 w-5" />
-              <span>4:3</span>
-            </div>
-          </SelectItem>
-          <SelectItem value="1:1">
-            <div className="flex gap-4">
-              <Icons.smartphone className="h-5 w-5" />
-              <span>1:1</span>
-            </div>
-          </SelectItem>
-          <SelectItem value="4:5">
-            <div className="flex gap-4">
-              <Icons.smartphone className="h-5 w-5" />
-              <span>4:5</span>
-            </div>
-          </SelectItem>
-          <SelectItem value="9:16">
-            <div className="flex gap-4">
-              <Icons.smartphone className="h-5 w-5" />
-              <span>9:16</span>
-            </div>
-          </SelectItem>
+          {Object.keys(MapAspectRatioToIcons).map((key) => (
+            <SelectItem value={key} key={key}>
+              <div className="flex gap-4">
+                {MapAspectRatioToIcons[key]}
+                <span>{key}</span>
+              </div>
+            </SelectItem>
+          ))}
         </SelectContent>
       </Select>
       <div className="flex justify-between items-center ">

--- a/app/(flickz)/projects/[projectId]/editor/Editor.tsx
+++ b/app/(flickz)/projects/[projectId]/editor/Editor.tsx
@@ -10,18 +10,20 @@ import TypographyMenu from "./TypographyMenu";
 import AspectRatioMenu from "./AspectRatioMenu";
 import AnimationMenu from "./AnimationMenu";
 import { Icons } from "@/components/icons";
-import { updateFramesAction } from "@/actions";
+import { updateFramesAction, updateProjectAction } from "@/actions";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import MediaMenu from "./MediaMenu";
+import { getDimensionsForAspectRatio } from "@/lib/aspect-ratio";
+import { useRouter } from "next/navigation";
 
 const fps = 60;
 export default function Editor({
   defaultFrames,
-  projectId,
+  project,
 }: {
   defaultFrames: frameInputType[];
-  projectId: string;
+  project: EditorProjectType;
 }) {
   const [frames, setFrames] = useState<frameInputType[]>(defaultFrames);
   const playerRef = useRef<PlayerRef>(null);
@@ -34,6 +36,7 @@ export default function Editor({
     height: 1080,
     width: 1920,
   });
+  const router = useRouter();
   const moveUp = (inputIndex: number) => {
     if (inputIndex > 0) {
       let tempFrames = [...frames];
@@ -106,10 +109,33 @@ export default function Editor({
     if (edited) {
       let tempFrames = [...frames];
       tempFrames[currentFrame].text = `${currentFrameContent}`;
-      await updateFramesAction(projectId, tempFrames);
+      await updateFramesAction(project.id, tempFrames);
       setEdited(false);
     }
   }, [edited]);
+
+  const saveProjectMetaChanges = async ({
+    aspectRatio,
+    audioLink,
+  }: {
+    aspectRatio?: string;
+    audioLink?: string;
+  }) => {
+    let newProjectData = {
+      ...project,
+      aspectRatio: aspectRatio,
+      audioLink: audioLink,
+    };
+    await updateProjectAction(project.id, newProjectData);
+    router.refresh();
+  };
+
+  useEffect(() => {
+    if (project.aspectRatio) {
+      const newDimensions = getDimensionsForAspectRatio(project.aspectRatio);
+      setCompositionDimensions(newDimensions);
+    }
+  }, [project]);
 
   useEffect(() => {
     const autoSave = setInterval(() => {
@@ -254,6 +280,8 @@ export default function Editor({
           </TabsContent>
           <TabsContent value="ratio">
             <AspectRatioMenu
+              aspectRatio={project.aspectRatio}
+              saveProjectMetaChanges={saveProjectMetaChanges}
               setCompositionDimensions={setCompositionDimensions}
             />
           </TabsContent>

--- a/app/(flickz)/projects/[projectId]/editor/page.tsx
+++ b/app/(flickz)/projects/[projectId]/editor/page.tsx
@@ -16,6 +16,7 @@ export default async function EditorPageWrap({
     select: {
       id: true,
       name: true,
+      aspectRatio: true,
     },
   });
 
@@ -49,6 +50,8 @@ export default async function EditorPageWrap({
       index: "asc",
     },
   });
-  // @ts-ignore
-  return <Editor defaultFrames={frames} projectId={projectId} />;
+  return (
+    // @ts-ignore
+    <Editor defaultFrames={frames} project={project} />
+  );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,7 +68,7 @@ model Project {
   userId      String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
-  aspectRatio String?
+  aspectRatio String?  @default("16:9")
   audioLink   String?
   Frame       Frame[]
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -15,3 +15,11 @@ type frameInputType = {
   backgroundImgLink?: string;
   backgroundVideoLink?: string;
 };
+
+// the type of project used in editor
+type EditorProjectType = {
+  id: string;
+  name: string;
+  aspectRatio?: string;
+  audioLink?: string;
+};


### PR DESCRIPTION
Following are added/ensured:
- Save aspect ratio to DB on change in drop-down menu
- Load frame with default aspect-ratio as received from DB
- Fixed the bug in drop-down to show related icon by creating a dict-mapping
- A generic update project action, can also be used to save audioLink 

I've modified schema to add default value of 16:9 for all projects